### PR TITLE
Spanish translation for 0.2.1

### DIFF
--- a/strings_es.json
+++ b/strings_es.json
@@ -116,10 +116,10 @@
 		"ext_playtesting": "Pruebas externas",
 		"spanish_localization": "Localización a español",
 		"german_localization": "Localización a alemán",
-        "polish_localization" : "Localización a polaca",
-        "french_localization" : "Localización a francesa",
-		"korean_localization" : "Localización a coreana",
-		"japanese_localization" : "Localización a japonesa",
+        	"polish_localization" : "Localización a polaco",
+        	"french_localization" : "Localización a francés",
+		"korean_localization" : "Localización a coreano",
+		"japanese_localization" : "Localización a japonés",
 		"special_thanks": "Agradecimientos especiales"
 	}
 }


### PR DESCRIPTION
Note: Google Translate seems to use the feminine form of the languages when translating from English to Spanish, since that's the only change I made.